### PR TITLE
Move to h8io/gha v6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,8 @@ permissions:
   contents: write
 
 jobs:
-  snapshot:
+  release:
     secrets: inherit
-    uses: h8io/gha/.github/workflows/release.yaml@v3
+    uses: h8io/gha/.github/workflows/release.yaml@v6
     with:
       java-version: 17

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -9,6 +9,6 @@ permissions:
 jobs:
   snapshot:
     secrets: inherit
-    uses: h8io/gha/.github/workflows/snapshot.yaml@v3
+    uses: h8io/gha/.github/workflows/snapshot.yaml@v6
     with:
       java-version: 17

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,6 @@ on:
 jobs:
   test:
     secrets: inherit
-    uses: h8io/gha/.github/workflows/test.yaml@v3
+    uses: h8io/gha/.github/workflows/test.yaml@v6
     with:
       timeout-minutes: 5

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+sbt +clean +test ci-release

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+sbt +clean +compile ci-release


### PR DESCRIPTION
## Why

From the `v6` series `h8io/gha` carries no build commands: every workflow runs a script from the repository it is called from, named after it. Keeping the sbt command in shared CI meant one repository migrating to sbt 2 could not be told apart from another still on sbt 1 — that is what pinned `stages` to the `v3` series for a year.

## What changed

- `release.sh` and `snapshot.sh` hold exactly what `release.yaml` and `snapshot.yaml` used to spell out, unchanged.
- All three workflow stubs move to `@v6`.
- The job in `release.yaml` was called `snapshot`, copied from the workflow next to it. Renamed to `release`, which is only a label in the Actions UI.

Nothing about the build changes. `publish-pages` is left off — this repository has no documentation site to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)