### PR TITLE
Point scmInfo at this repository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,9 +19,7 @@ ThisBuild / developers := List(
     url = url("https://github.com/eshu/")))
 
 ThisBuild / scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/h8io/sbt-scoverage-summary"),
-    "scm:git@github.com:h8io/sbt-scoverage-summary.git"))
+  ScmInfo(url("https://github.com/h8io/xi"), "scm:git@github.com:h8io/xi.git"))
 
 ThisBuild / dynverSonatypeSnapshots := true
 ThisBuild / dynverSeparator := "-"


### PR DESCRIPTION
## Why

`ThisBuild / scmInfo` named `sbt-scoverage-summary` — in both the browse URL and the connection string — copied from wherever this build was seeded. `homepage` and `organizationHomepage` were already correct, so this was the one field left pointing elsewhere.

It goes into the POM of every release, so anything following the metadata of a published `xi` artifact back to its source has been sent to a different project.

## Verification

```
sbt> show scmInfo
Some(ScmInfo(https://github.com/h8io/xi, scm:git@github.com:h8io/xi.git, None))
sbt> show homepage
Some(https://github.com/h8io/xi)
```

`scalafmtSbtCheck` passes.

Independent of #146, which touches only the workflows and the scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)