### PR TITLE
Inherit the test timeout instead of pinning it

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,5 +13,3 @@ jobs:
   test:
     secrets: inherit
     uses: h8io/gha/.github/workflows/test.yaml@v6
-    with:
-      timeout-minutes: 5


### PR DESCRIPTION
## Why

`timeout-minutes: 5` was never chosen here — it spread by copy-paste across the organisation, and it stopped being a safety net some time ago. The setting is meant to cut off a job that has hung, not to measure one that is working.

h8io/gha#38 raises the shared default to 15 for exactly that reason. Dropping the line means inheriting it, rather than pinning a number that no longer says anything about this build.

Nothing changes until `gha` releases `v6.1.0` — until then the inherited default is the same 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)