### PR TITLE
Fail the build on insufficient coverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,11 @@ ThisBuild / licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses
 
 ThisBuild / versionScheme := Some("semver-spec")
 
+ThisBuild / coverageSummaryStmtLowThreshold := 100
+ThisBuild / coverageSummaryStmtHighThreshold := 100
+ThisBuild / coverageSummaryBranchLowThreshold := 100
+ThisBuild / coverageSummaryBranchHighThreshold := 100
+
 ThisBuild / developers := List(
   Developer(
     id = "eshu",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
 addSbtPlugin("io.h8.sbt" %% "sbt-dependencies" % "1.1.1")
-addSbtPlugin("io.h8.sbt" % "sbt-scoverage-summary" % "1.1.2")
-addSbtPlugin("io.h8.sbt" % "sbt-testkit" % "2.1.1")
+addSbtPlugin("io.h8.sbt" % "sbt-scoverage-summary" % "2.0.0")
+addSbtPlugin("io.h8.sbt" % "sbt-testkit" % "2.2.0")

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 
 set -euxo pipefail
 
-sbt scalafmtSbtCheck scalafmtCheckAll +clean +coverage +test +coverageSummary +coverageAggregate
+sbt scalafmtSbtCheck scalafmtCheckAll +clean +coverage +test +coverageSummary +coverageAggregate +coverageSummaryCheck


### PR DESCRIPTION
## What changed

- `sbt-scoverage-summary` 1.1.2 → **2.0.0**
- thresholds declared per metric — the old `coverageSummaryLowThreshold` / `HighThreshold` pair no longer exists, and statement and branch rates are uncorrelated enough to deserve their own numbers
- `+coverageSummaryCheck` appended to `test.sh`, which is what makes the build fail rather than merely report

## The numbers

Measured before choosing: **100% statement, 100% branch**, on both Scala versions. So the gate is `low = high = 100` — this build is already there, and the threshold says it has to stay.

## Verified that the gate bites

A green `test.sh` only proves the command runs. With a test file moved aside the build fails with

```
[root] Statement coverage is 0.00%, below the required 100.00%
```

— the bar that was set, not the 50% default that an unconfigured build would report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also

`sbt-testkit` 2.1.1 → 2.2.0. This build never sets `publishTestKitArtifacts`, the flag that release fixes, so nothing changes for it.