### PR TITLE
Take Tagged over from cfg

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,15 @@ import sbt.*
 
 object Dependencies {
   private val CatsVersion = "2.13.0"
+  private val CfgVersion = "0.0.12"
 
   val H8IO: Seq[ModuleID] =
-    Seq("io.h8" %% "stages" % "0.0.4", "io.h8" %% "cfg" % "0.0.11", "io.h8" %% "reflect" % "0.0.4")
+    Seq(
+      "io.h8" %% "stages" % "0.0.4",
+      "io.h8" %% "cfg" % CfgVersion,
+      "io.h8" %% "cfg-schema" % CfgVersion,
+      "io.h8" %% "reflect" % "0.0.4"
+    )
 
   val TestBundle: Seq[ModuleID] =
     Seq(

--- a/src/main/scala/h8io/xi/cfg/Tagged.scala
+++ b/src/main/scala/h8io/xi/cfg/Tagged.scala
@@ -1,0 +1,33 @@
+package h8io.xi.cfg
+
+import cats.syntax.all.*
+import h8io.cfg.Node
+import h8io.cfg.schema.{CfgValue, Decoder, SelectiveDecoder}
+import h8io.xi.cfg.errors.{AmbiguousMap, NonScalarTag}
+
+final case class Tagged(tag: String, node: Node.Some)
+
+object Tagged {
+  val decoder: Decoder[Tagged] = new SelectiveDecoder[Tagged] {
+    override def parse(scalar: Node.Scalar): CfgValue[Tagged] =
+      scalar.tag match {
+        case Some(tag) => Tagged(tag, scalar).valid
+        case None => Tagged(scalar.value, Node.Null(scalar.id, None, scalar.location)).valid
+      }
+
+    override def parse(map: Node.Map): CfgValue[Tagged] =
+      map.tag match {
+        case Some(tag) => Tagged(tag, map).valid
+        case None =>
+          map("_") match {
+            case scalar: Node.IScalar[?] => Tagged(scalar.value, map - "_").valid
+            case _: Node.ISome[?] => NonScalarTag(map).invalid
+            case _ =>
+              if (map.size == 1) {
+                val entry = map.iterator.next()
+                Tagged(entry.id.key, entry).valid
+              } else AmbiguousMap(map).invalid
+          }
+      }
+  }
+}

--- a/src/main/scala/h8io/xi/cfg/errors/TagError.scala
+++ b/src/main/scala/h8io/xi/cfg/errors/TagError.scala
@@ -1,0 +1,8 @@
+package h8io.xi.cfg.errors
+
+import h8io.cfg.{Node, NodeError}
+
+sealed trait TagError extends NodeError
+
+final case class NonScalarTag(node: Node.Map) extends TagError
+final case class AmbiguousMap(node: Node.Map) extends TagError

--- a/src/main/scala/h8io/xi/stages/StageBuilder.scala
+++ b/src/main/scala/h8io/xi/stages/StageBuilder.scala
@@ -1,8 +1,7 @@
 package h8io.xi.stages
 
 import cats.data.Validated
-import h8io.cfg.NodeError
-import h8io.cfg.raw.Node
+import h8io.cfg.{Node, NodeError}
 import h8io.reflect.Type
 
 trait StageBuilder[E] {

--- a/src/test/scala/h8io/xi/cfg/TaggedDecoderTest.scala
+++ b/src/test/scala/h8io/xi/cfg/TaggedDecoderTest.scala
@@ -1,0 +1,78 @@
+package h8io.xi.cfg
+
+import cats.syntax.all.*
+import h8io.cfg.{Id, Node}
+import h8io.xi.cfg.errors.{AmbiguousMap, NonScalarTag}
+import h8io.xi.cfg.testutil.MockLocation
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TaggedDecoderTest extends AnyFlatSpec with Matchers with MockFactory {
+  private val loc = MockLocation("loc")
+
+  "taggedDecoder" should "return the node as-is when it already has a tag" in {
+    val map = mock[Node.Map]
+    (() => map.tag).expects().returns(Some("existing"))
+    Tagged.decoder(map) shouldBe Tagged("existing", map).valid
+  }
+
+  it should "use _ scalar as tag and strip it from the map" in {
+    val map = mock[Node.Map]
+    val stripped = mock[Node.Map]
+    val scalar = Node.Scalar(Id.Key("_", Id.Root), None, "myTag", loc)
+    (() => map.tag).expects().returns(None)
+    (() => map.id).expects().returns(Id.Root)
+    (map.apply(_: Id.Key)).expects(Id.Key("_", Id.Root)).returns(scalar)
+    (map.-(_: String)).expects("_").returns(stripped)
+    Tagged.decoder(map) shouldBe Tagged("myTag", stripped).valid
+  }
+
+  it should "return NonScalarTag when _ key is not a scalar" in {
+    val map = mock[Node.Map]
+    val nullNode = Node.Null(Id.Key("_", Id.Root), None, loc)
+    (() => map.tag).expects().returns(None)
+    (() => map.id).expects().returns(Id.Root)
+    (map.apply(_: Id.Key)).expects(Id.Key("_", Id.Root)).returns(nullNode)
+    Tagged.decoder(map) shouldBe NonScalarTag(map).invalid
+  }
+
+  it should "use the single key as tag when no _ key present" in {
+    val map = mock[Node.Map]
+    val value = Node.Scalar(Id.Key("kind", Id.Root), None, "circle", loc)
+    (() => map.tag).expects().returns(None)
+    (() => map.id).expects().returns(Id.Root)
+    (map.apply(_: Id.Key)).expects(Id.Key("_", Id.Root)).returns(Node.None(Id.Key("_", Id.Root), map))
+    (() => map.size).expects().returns(1)
+    (() => map.iterator).expects().returns(Iterator(value))
+    Tagged.decoder(map) shouldBe Tagged("kind", value).valid
+  }
+
+  it should "return AmbiguousMap when no _ key and multiple keys" in {
+    val map = mock[Node.Map]
+    (() => map.tag).expects().returns(None)
+    (() => map.id).expects().returns(Id.Root)
+    (map.apply(_: Id.Key)).expects(Id.Key("_", Id.Root)).returns(Node.None(Id.Key("_", Id.Root), map))
+    (() => map.size).expects().returns(3)
+    Tagged.decoder(map) shouldBe AmbiguousMap(map).invalid
+  }
+
+  it should "return AmbiguousMap for an empty map" in {
+    val map = mock[Node.Map]
+    (() => map.tag).expects().returns(None)
+    (() => map.id).expects().returns(Id.Root)
+    (map.apply(_: Id.Key)).expects(Id.Key("_", Id.Root)).returns(Node.None(Id.Key("_", Id.Root), map))
+    (() => map.size).expects().returns(0)
+    Tagged.decoder(map) shouldBe AmbiguousMap(map).invalid
+  }
+
+  it should "return the scalar as-is when it already has a tag" in {
+    val scalar = Node.Scalar(Id.Root, Some("existing"), "x", loc)
+    Tagged.decoder(scalar) shouldBe Tagged("existing", scalar).valid
+  }
+
+  it should "use the scalar value as tag and Node.Null as node when the scalar has no tag" in {
+    val scalar = Node.Scalar(Id.Root, None, "myTag", loc)
+    Tagged.decoder(scalar) shouldBe Tagged("myTag", Node.Null(Id.Root, None, loc)).valid
+  }
+}

--- a/src/test/scala/h8io/xi/cfg/testutil/MockLocation.scala
+++ b/src/test/scala/h8io/xi/cfg/testutil/MockLocation.scala
@@ -1,0 +1,5 @@
+package h8io.xi.cfg.testutil
+
+import h8io.cfg.Location
+
+final case class MockLocation(description: String) extends Location


### PR DESCRIPTION
`Tagged` is a convention about how a config encodes a sum type — read a tag off a node, or take a single-key map as tag plus payload — which is xi's business, not the schema layer's. cfg dropped it in h8io/cfg#105 on the understanding that it lands here, as `h8io.xi.cfg`. `TagError` comes along into `h8io.xi.cfg.errors`, since `NonScalarTag` and `AmbiguousMap` have no other producer. `MockLocation` is copied rather than imported because cfg does not publish its test sources.

That needs cfg 0.0.12: 0.0.11 predates node tags entirely, so there was nothing for the decoder to read. The bump also moves `h8io.cfg.raw.Node` to `h8io.cfg.Node` and splits the decoding half out into a separate `cfg-schema` artifact, hence the `StageBuilder` import change and the second module in `Dependencies`.

`./test.sh` is green on 2.12 and 2.13, coverage 100% of statements and of branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)