### PR TITLE
Give xi a documentation site

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   release:
@@ -14,3 +16,4 @@ jobs:
     uses: h8io/gha/.github/workflows/release.yaml@v6
     with:
       java-version: 17
+      publish-pages: true

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import Dependencies.*
 import h8io.sbt.dependencies.*
 import sbt.url
 
+val SiteRoot = "https://xi.h8.io/"
+
 ThisBuild / organization := "io.h8"
 ThisBuild / organizationName := "H8IO"
 ThisBuild / organizationHomepage := Some(url("https://github.com/h8io/"))
@@ -51,3 +53,14 @@ val root = (project in file(".")).settings(
   name := "xi",
   libraryDependencies ++= H8IO
 ).enablePlugins(ScoverageSummaryPlugin)
+
+val pages = (project in file("pages"))
+  .settings(
+    name := "xi-pages",
+    publish / skip := true,
+    publishLocal / skip := true,
+    tlSiteApiUrl := Some(url(s"${SiteRoot}api/scala-2.13/")),
+    tlSiteHelium ~= { _.site.mainNavigation(depth = 3) }
+  )
+  .dependsOn(root)
+  .enablePlugins(ScalaUnidocPlugin, TypelevelSitePlugin)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# xi
+
+`xi` builds [stages](https://stages.h8.io/) pipelines out of configuration: it reads a
+[cfg](https://cfg.h8.io/) node tree and turns it into stages wired together, so that a pipeline can be
+described in a config file rather than in code.
+
+The library is early and nothing is published yet. This page exists so that the documentation site has
+somewhere to grow from; expect it to say more once there is more to say.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
+addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.6.1")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.8.7")
 addSbtPlugin("io.h8.sbt" %% "sbt-dependencies" % "1.1.1")
 addSbtPlugin("io.h8.sbt" % "sbt-scoverage-summary" % "2.0.0")
 addSbtPlugin("io.h8.sbt" % "sbt-testkit" % "2.2.0")

--- a/release.sh
+++ b/release.sh
@@ -2,4 +2,15 @@
 
 set -euxo pipefail
 
-sbt +clean +test ci-release
+# The site is built before ci-release so that a broken build of it costs nothing: publishing to Maven Central is the
+# one step here that cannot be taken back, and everything that can still fail belongs in front of it.
+sbt +clean +test \
+    pages/clean +pages/unidoc pages/tlSite \
+    ci-release
+
+mkdir -p target/pages
+cp -pr pages/target/docs/site/. target/pages
+mkdir -p target/pages/api/scala-2.12
+cp -pr pages/target/scala-2.12/unidoc/. target/pages/api/scala-2.12
+mkdir -p target/pages/api/scala-2.13
+cp -pr pages/target/scala-2.13/unidoc/. target/pages/api/scala-2.13

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,7 @@
 
 set -euxo pipefail
 
-sbt scalafmtSbtCheck scalafmtCheckAll +clean +coverage +test +coverageSummary +coverageAggregate +coverageSummaryCheck
+sbt scalafmtSbtCheck scalafmtCheckAll \
+    +clean +coverage +test \
+    +coverageSummary +coverageAggregate +coverageSummaryCheck \
+    +doc +packagedArtifacts pages/clean +pages/unidoc pages/tlSite


### PR DESCRIPTION
Same shape as cfg and stages: `docs/` holds the markdown, a `pages` project builds it with mdoc and Laika and collects the scaladoc through unidoc, `release.sh` assembles `target/pages`, and the release workflow deploys it.

The site is built before `ci-release` for the reason the comment in `release.sh` gives, and `test.sh` gains the same steps so a broken site is caught on every pull request rather than during a release. Following stages rather than cfg on one point: `+pages/unidoc` runs in `test.sh` too, since `release.sh` runs it and `test.sh` is there to hit what a release would hit.

The content is a placeholder README — a page for the site to grow from, without an install snippet, because nothing is published yet.

`./test.sh` is green; the site renders with the API link pointing at `xi.h8.io/api/scala-2.13/`, and the assembled `target/pages` carries scaladoc for both 2.12 and 2.13.

**Needs two things outside this PR before a release can deploy it** — see the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)